### PR TITLE
Update nvm to use its current Github organization

### DIFF
--- a/Formula/nvm.rb
+++ b/Formula/nvm.rb
@@ -1,9 +1,9 @@
 class Nvm < Formula
   desc "Manage multiple Node.js versions"
-  homepage "https://github.com/creationix/nvm"
-  url "https://github.com/creationix/nvm/archive/v0.35.2.tar.gz"
+  homepage "https://github.com/nvm-sh/nvm"
+  url "https://github.com/nvm-sh/nvm/archive/v0.35.2.tar.gz"
   sha256 "520c1909d702a68c1334abc24027075ed65ac331bbc4d5b5895203517090bc54"
-  head "https://github.com/creationix/nvm.git"
+  head "https://github.com/nvm-sh/nvm.git"
 
   bottle :unneeded
 


### PR DESCRIPTION
Update from creationix to current nvm-sh organization.  As it is, everytime the old URLs are hit they redirect to the new ones.  Updating the formula will avoid these redirects.

I was not able to figure out how to test this locally following the included or linked instructions.

- [X] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/master/CONTRIBUTING.md)?
- [X] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [ ] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
  - `brew install -s nvm --include-test` gives an error about version
- [ ] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
